### PR TITLE
Prefetch option

### DIFF
--- a/lib/sixpack.rb
+++ b/lib/sixpack.rb
@@ -50,7 +50,7 @@ module Sixpack
       end
     end
 
-    def participate(experiment_name, alternatives, force=nil, kpi=nil, traffic_fraction=nil, record_force=false)
+    def participate(experiment_name, alternatives, force=nil, kpi=nil, traffic_fraction=nil, record_force=false, prefetch=false)
       if !(experiment_name =~ /^[a-z0-9][a-z0-9\-_ ]*$/)
         raise ArgumentError, "Bad experiment_name, must be lowercase, start with an alphanumeric and contain alphanumerics, dashes and underscores"
       end
@@ -74,9 +74,10 @@ module Sixpack
       end
 
       params = {
-        :client_id => @client_id,
-        :experiment => experiment_name,
-        :alternatives => alternatives
+        client_id: @client_id,
+        experiment: experiment_name,
+        alternatives: alternatives,
+        prefetch: prefetch
       }
       params = params.merge(kpi: kpi) if kpi
       params = params.merge(traffic_fraction: traffic_fraction) if traffic_fraction

--- a/spec/lib/sixpack_spec.rb
+++ b/spec/lib/sixpack_spec.rb
@@ -70,10 +70,27 @@ RSpec.describe Sixpack do
                             experiment: experiment_name,
                             alternatives: alternatives,
                             force: 'trolled',
+                            prefetch: false,
                             record_force: true)
                       .and_return({})
 
     sess.participate(experiment_name, alternatives, 'trolled', nil, nil, true)
+  end
+
+  it 'should include the prefetch in the outgoing request' do
+    experiment_name = 'experiment_name'
+    alternatives = ['variant', 'control']
+
+    sess = Sixpack::Session.new('client_id')
+    expect(sess).to receive(:get_response)
+                      .with('/participate',
+                            client_id: 'client_id',
+                            experiment: experiment_name,
+                            alternatives: alternatives,
+                            prefetch: true)
+                      .and_return({})
+
+    sess.participate(experiment_name, alternatives, nil, nil, nil, nil, true)
   end
 
   it "should allow ip and user agent to be passed to a session" do
@@ -213,7 +230,8 @@ RSpec.describe Sixpack do
               client_id: '123',
               experiment: experiment_name,
               alternatives: alternatives,
-              traffic_fraction: '0.5')
+              traffic_fraction: '0.5',
+              prefetch: false)
         .and_return({})
 
       sess.participate(experiment_name, alternatives, nil, nil, '0.5')


### PR DESCRIPTION
With the prefetch option set to `true`, sixpack will return a selected variation without recording the participation on the experiment. 